### PR TITLE
Fix undefined function in draft start logic

### DIFF
--- a/public/html/draft.html
+++ b/public/html/draft.html
@@ -723,6 +723,13 @@
                 registerPick(teamIdx, pick);
             }
 
+            // Skip CPU selections until it's the user's turn
+            function advanceToUser() {
+                while (overallPick <= totalPicks && currentTeamIdx() !== userSlot) {
+                    cpuPick();
+                }
+            }
+
 
             function showReportCard() {
                 /* gather user picks */
@@ -770,16 +777,6 @@
                 }
             }
 
-
-            /* ========== User action ========= */
-            function userDraft(player, row, btn) {
-                if (draftedIds.has(player.id)) return;
-                registerPick(userSlot, player);
-                row.classList.add('drafted');
-                btn.disabled = true;
-                renderBoard(); renderRoster(); updateClock();
-                if (overallPick <= totalPicks) { advanceToUser(); renderPlayerList(); }
-            }
 
             /* ========== Kick‑off ========= */
             /* ────────────────────────────── Kick‑off & engine */


### PR DESCRIPTION
## Summary
- remove duplicate `userDraft` definition
- add missing `advanceToUser()` helper to skip CPU picks until the user is up

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f9888269c83268dbd125291a50f24