### PR TITLE
Fix ADP drift range slider padding

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -48,6 +48,12 @@ select {
     border-radius: 4px;
 }
 
+/* Ensure range sliders span the full track without extra padding */
+input[type=range] {
+    padding: 0;
+    border: none;
+}
+
 button {
     display: block;
     width: 100%;


### PR DESCRIPTION
## Summary
- improve styling for range sliders so ADP Drift fills from 0 to 100%

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840eccc0f448326be8f99250d76a2b5