### PR TITLE
Limit large ADP slides

### DIFF
--- a/public/html/draft.html
+++ b/public/html/draft.html
@@ -716,6 +716,13 @@
                 const avail = players.filter(p => !draftedIds.has(p.id));
                 if (!avail.length) return;
 
+                /* force pick if best available has fallen too far */
+                const slipLimit = Math.max(5, drift * 2); // tighter with lower drift
+                if (overallPick - avail[0].rank.overall >= slipLimit) {
+                    registerPick(teamIdx, avail[0]);
+                    return;
+                }
+
                 let looseness = (overallPick / totalPicks) +
                     drift / 100 * Math.max(0, round - 5) / rounds;
 


### PR DESCRIPTION
## Summary
- prevent CPU teams from letting the top ranked player slip too many picks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68422161ae148326ab4d6c9727faf6bd