### PR TITLE
Clean up draft settings

### DIFF
--- a/public/html/index.html
+++ b/public/html/index.html
@@ -78,7 +78,7 @@
             <!-- Draft behaviour -->
             <fieldset class="border p-4 rounded">
                 <legend class="font-semibold px-2">Draft&nbsp;Behaviour</legend>
-                <div class="grid md:grid-cols-3 gap-4">
+                <div class="grid md:grid-cols-2 gap-4">
                     <label>Draft&nbsp;Order
                         <select id="draft-order" name="draftOrder" required>
                             <option value="snake" selected>Snake</option>
@@ -86,22 +86,12 @@
                         </select>
                     </label>
 
-                    <label>Pick&nbsp;Timer&nbsp;(seconds)
-                        <input type="number" name="pickTimer" value="60" min="15" max="300" step="15" required>
-                    </label>
-                    
-                    <label>CPU&nbsp;Difficulty
-                        <select id="cpu-difficulty" name="cpuDifficulty" required>
-                            <option value="normal" selected>Normal</option>
-                            <option value="chaotic">Chaotic (More random, late reaches)</option>
-                            <option value="sharp">Sharp (Values ADP aggressively)</option>
-                        </select>
-                    </label>
-
                     <label style="display:block;margin-top:1rem">
                         ADP Drift <span id="drift-value" style="font-weight:600">30</span>
                         <input type="range" id="adp-drift" name="adpDrift" min="0" max="100" step="10" value="30"
-                            style="width:100%;margin-top:4px">              </label>
+                            style="width:100%;margin-top:4px">
+                        <small class="block text-gray-600">Controls how much CPU picks deviate from Average Draft Position. 0 = strict ADP, 100 = totally random.</small>
+                    </label>
                 </div>
             </fieldset>
 
@@ -153,7 +143,6 @@
                 data.numTeams = Number(data.numTeams);
                 data.userPick = Number(data.userPick);
                 data.numRounds = Number(data.numRounds);
-                data.pickTimer = Number(data.pickTimer);
                 data.adpDrift = Number(data.adpDrift);
 
                 // Roster sanity check


### PR DESCRIPTION
## Summary
- drop CPU difficulty and pick timer options from setup
- explain the ADP drift slider for clarity

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844e10199648326b3848eb1bb81e7b7