### PR TITLE
Enhance draft grade weighting

### DIFF
--- a/public/html/draft.html
+++ b/public/html/draft.html
@@ -767,14 +767,22 @@
                     };
                 });
 
-                /* grade scale based on avg diff */
-                const avg = deltas.reduce((s, d) => s + d.diff, 0) / deltas.length;
+                /* grade scale based on weighted avg diff */
+                const weightForRound = r => r <= 5 ? 3 : r <= 10 ? 2 : 1;
+                const totals = deltas.reduce((obj, d) => {
+                    const round = Math.ceil(d.pick / numTeams);
+                    const w = weightForRound(round);
+                    obj.weight += w;
+                    obj.score += d.diff * w;
+                    return obj;
+                }, { weight: 0, score: 0 });
+                const avg = totals.score / totals.weight;
                 const grade = avg >= 15 ? 'A' : avg >= 8 ? 'B' : avg >= 0 ? 'C' : avg >= -8 ? 'D' : 'F';
 
                 /* populate modal */
                 document.getElementById('grade-letter').textContent = grade;
                 document.getElementById('grade-summary').textContent =
-                    `Average value: ${avg.toFixed(1)} picks ${avg >= 0 ? 'ahead of' : 'behind'} ADP`;
+                    `Weighted value: ${avg.toFixed(1)} picks ${avg >= 0 ? 'ahead of' : 'behind'} ADP`;
 
                 const best = [...deltas].sort((a, b) => b.diff - a.diff).slice(0, 3);
                 const worst = [...deltas].sort((a, b) => a.diff - b.diff).slice(0, 3);


### PR DESCRIPTION
## Summary
- weight early draft picks more heavily when calculating report card average
- show a weighted value summary in the draft report card

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844e58555d48326912d02e765cacc79