### PR TITLE
Improve draft page styling

### DIFF
--- a/public/html/draft.html
+++ b/public/html/draft.html
@@ -30,17 +30,18 @@
         }
 
         header {
-            background: #1e293b;
+            background: linear-gradient(135deg, #1e293b, #334155);
             color: #fff;
             padding: 14px 16px;
             position: sticky;
             top: 0;
             z-index: 40;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         }
 
         header h1 {
             margin: 0;
-            font-size: 18px;
+            font-size: 20px;
             font-weight: 700;
         }
 
@@ -61,6 +62,9 @@
             align-items: center;
             justify-content: center;
         }
+        .search-btn:hover {
+            color: #d1d5db;
+        }
 
         /* tab row */
         nav.tabs {
@@ -80,6 +84,12 @@
             padding: 10px 0;
             border: none;
             background: none;
+            cursor: pointer;
+            transition: background .2s;
+        }
+
+        nav.tabs button:hover {
+            background: #f3f4f6;
         }
 
         nav.tabs button.active {
@@ -106,6 +116,16 @@
             border-radius: 9999px;
             font-weight: 600;
             background: #e5e7eb;
+            cursor: pointer;
+            transition: background .2s;
+        }
+        #pos-filters button:hover {
+            background: #d1d5db;
+        }
+
+        #pos-filters button.active {
+            background: var(--indigo);
+            color: #fff;
         }
 
         #pos-filters button.active {
@@ -165,11 +185,24 @@
             color: #fff;
             cursor: pointer;
         }
+        .queue-btn {
+            color: #d1d5db;
+            cursor: pointer;
+        }
+        .queue-btn:hover {
+            color: var(--indigo);
+        }
+        .draft-btn:not(:disabled):hover {
+            background: #4f46e5;
+        }
 
         .draft-btn:disabled {
             background: #d1d5db;
             color: var(--muted);
             cursor: default;
+        }
+        #start-btn:hover {
+            background: #4f46e5;
         }
 
         /* board grid */
@@ -204,13 +237,18 @@
             border-radius: 9999px;
             background: #e5e7eb;
             font-weight: 600;
+            cursor: pointer;
+            transition: background .2s;
+        }
+
+        #team-tabs button:hover {
+            background: #d1d5db;
         }
 
         #team-tabs button.active {
             background: var(--indigo);
             color: #fff;
         }
-
         .roster-row {
             display: flex;
             justify-content: space-between;
@@ -228,6 +266,16 @@
 
         .hidden {
             display: none;
+        }
+        #queue-bar {
+            display: none;
+            background: #fff;
+            padding: 6px 12px;
+            margin-bottom: 8px;
+            border-radius: 6px;
+            box-shadow: 0 1px 2px rgba(0,0,0,.05);
+            font-size: 12px;
+            color: var(--muted);
         }
 
         .player-ppg {
@@ -316,9 +364,7 @@
                 </svg>
             </button>
         </div>
-        <button id="restart-btn" style="margin-left:auto;padding:4px 10px;
-                       border:1px solid #94a3b8;border-radius:4px;
-                       background:#fff;color:#0f172a;font-size:12px;font-weight:600;">
+        <button id="restart-btn" style="margin-left:auto;padding:4px 10px;border:1px solid #94a3b8;border-radius:6px;background:#fff;color:#0f172a;font-size:12px;font-weight:600;box-shadow:0 1px 2px rgba(0,0,0,.05);">
             Restart
         </button>
 
@@ -337,9 +383,9 @@
     <!-- ───── Main viewport -->
     <main>
         <!-- put this just under the <main> opening tag -->
-        <button id="start-btn" style="display:block;margin:24px auto 12px; padding:8px 20px;
-                       background:var(--indigo);color:#fff;border:none;border-radius:6px;
-                       font-weight:700;font-size:16px">
+        <button id="start-btn" style="display:block;margin:24px auto 12px; padding:10px 24px;
+                       background:var(--indigo);color:#fff;border:none;border-radius:8px;
+                       font-weight:700;font-size:16px;box-shadow:0 2px 4px rgba(0,0,0,.1)">
             Start Draft
         </button>
 


### PR DESCRIPTION
## Summary
- add subtle gradient and shadow to header
- tweak tab, filter, and team button styles with hover effects
- style queue bar and queue button
- enhance Restart and Start buttons with rounded corners and shadow

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68461d7fc86c8326991f3ef6a9e86f30