### PR TITLE
Increase early round realism

### DIFF
--- a/public/html/draft.html
+++ b/public/html/draft.html
@@ -767,7 +767,11 @@
                 if (!avail.length) return;
 
                 /* force pick if best available has fallen too far */
-                const slipLimit = Math.max(5, drift * 2); // tighter with lower drift
+                let slipLimit = Math.max(5, drift * 2); // tighter with lower drift
+                if (round <= 3) {
+                    const earlyLimits = { 1: 10, 2: 12, 3: 18 };
+                    slipLimit = Math.min(slipLimit, earlyLimits[round]);
+                }
                 if (overallPick - avail[0].rank.overall >= slipLimit) {
                     registerPick(teamIdx, avail[0]);
                     return;


### PR DESCRIPTION
## Summary
- refine CPU draft picks to cap how far top players can slide

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846287dc77c8326aaca1d05061e9891