### PR TITLE
Add FantasyDraftSim logo to headers

### DIFF
--- a/public/html/draft.html
+++ b/public/html/draft.html
@@ -364,7 +364,7 @@
     <!-- ───── Header: “You’re on the clock” strip -->
     <header>
         <div class="header-left">
-            <div class="logo-circle"></div>
+            <img src="../images/FantasyDraftSimLogo.png" alt="Fantasy Draft Sim Logo" style="height:40px;border-radius:50%;" />
             <div>
                 <h1 id="clock-title">Your Pick!</h1>
                 <p id="clock-sub">Pick&nbsp;<span id="clock-pick">1.01</span>&nbsp;(<span id="clock-overall">1</span>&nbsp;Overall)</p>

--- a/public/html/index.html
+++ b/public/html/index.html
@@ -11,6 +11,7 @@
 
 <body>
     <header style="background:linear-gradient(90deg,#1e3a8a,#9333ea);color:#fff;text-align:center;padding:20px 0;">
+        <img src="../images/FantasyDraftSimLogo.png" alt="Fantasy Draft Sim Logo" style="height:60px;margin-bottom:8px;border-radius:50%;" />
         <h1 style="margin:0;font-size:1.75rem">NFL Fantasy Football Draft Simulator</h1>
         <p style="margin:4px 0 0;font-size:0.9rem">Set up your league and start drafting in seconds</p>
     </header>


### PR DESCRIPTION
## Summary
- display FantasyDraftSimLogo.png in index header
- show logo in draft page header

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848b1d344848326b727dc0ed11e78bf